### PR TITLE
chore: Fix deploy error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
           bundle exec htmlproofer --url-ignore "/#.*/,/tofuconf.club/.*/" ./_site
 
       - name: Prepare SSH 1
-        uses: webfactory/ssh-agent@v0.2.0
+        uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 


### PR DESCRIPTION
Details of the error
```
Adding GitHub.com keys to /home/runner/.ssh/known_hosts
Starting ssh-agent
Error: Unable to process command '##[set-env name=SSH_AUTH_SOCK;]/tmp/ssh-auth.sock' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Identity added: (stdin) ((stdin))
Adding private key to agent
```