### PR TITLE
ci: Ignore HTTP 400 and 999 on html-proofer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Verify URL in HTML
         continue-on-error: true
         run: |
-          bundle exec htmlproofer --url-ignore "/#.*/,/tofuconf.club/.*/" ./_site
+          bundle exec htmlproofer --http-status-ignore "400,999" --url-ignore "/#.*/,/tofuconf.club/.*/" ./_site
 
       - name: Prepare SSH 1
         uses: webfactory/ssh-agent@v0.4.1

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Verify URL in HTML
         run: |
-          bundle exec htmlproofer --url-ignore "/#.*/,/tofuconf.club/.*/" ./_site
+          bundle exec htmlproofer --http-status-ignore "400,999" --url-ignore "/#.*/,/tofuconf.club/.*/" ./_site
 
       - name: Deploy to Netlify
         if: ${{ always() }}


### PR DESCRIPTION
build log of [runs/1634560800](https://github.com/tofuconf/tofuconf.club/runs/1634560800?check_suite_focus=true): [1_build.txt](https://github.com/tofuconf/tofuconf.club/files/5761727/1_build.txt)

```
Run bundle exec htmlproofer --url-ignore "/#.*/,/tofuconf.club/.*/" ./_site
Running ["ImageCheck", "LinkCheck", "ScriptCheck"] on ["./_site"] on *.html... 


Checking 66 external links...
Ran on 39 files!


- ./_site/2018-01-15/we-held-the-1st-tofuconf.html
  *  External link https://t.co/PyqVSBV70L failed: 400 No error
  *  External link https://twitter.com/hashtag/tofuConf17?src=hash&ref_src=twsrc%5Etfw failed: 400 No error
  *  External link https://twitter.com/hashtag/tofuconf17 failed: 400 No error
  *  External link https://twitter.com/tofuConf/status/919118026661797888?ref_src=twsrc%5Etfw failed: 400 No error
  *  External link https://twitter.com/tofuConf/status/919826069628129280?ref_src=twsrc%5Etfw failed: 400 No error
- ./_site/2018-01-28/1st-tofuconf-review.html
  *  External link https://twitter.com/tofuConf/status/920259667237863424 failed: 400 No error
- ./_site/2018-03-25/we-held-the-2nd-tofuconf.html
  *  External link https://t.co/ByX27HUqg7 failed: 400 No error
  *  External link https://t.co/MDXw1OMQth failed: 400 No error
  *  External link https://twitter.com/tofuConf/status/977776294849953792?ref_src=twsrc%5Etfw failed: 400 No error
  *  External link https://twitter.com/tofuConf/status/977792867249762306?ref_src=twsrc%5Etfw failed: 400 No error
- ./_site/2018-10-15/3rd-tofuconf-general.html
  *  External link https://twitter.com/tofuConf failed: 400 No error
- ./_site/2018-11-03/we-held-the-3rd-tofuconf.html
  *  External link https://t.co/juBzGl8x0g failed: 400 No error
  *  External link https://twitter.com/hashtag/tofuConf failed: 400 No error
  *  External link https://twitter.com/hashtag/tofuConf?src=hash&ref_src=twsrc%5Etfw failed: 400 No error
  *  External link https://twitter.com/tofuConf/status/1058602586863849478?ref_src=twsrc%5Etfw failed: 400 No error
- ./_site/2018-11-22/3rd-tofuconf-review.html
  *  External link https://t.co/i5zuq94WGN failed: 400 No error
  *  External link https://twitter.com/tofuConf/status/1065598803389149185?ref_src=twsrc%5Etfw failed: 400 No error
  *  External link https://twitter.com/tofuConf/status/1067699069445824512?ref_src=twsrc%5Etfw failed: 400 No error
- ./_site/2019-03-17/we-held-the-4th-tofuconf.html
  *  External link https://t.co/JhKmiGTwEK failed: 400 No error
  *  External link https://twitter.com/tofuConf/status/1106779692256784384?ref_src=twsrc%5Etfw failed: 400 No error
- ./_site/2020-06-04/we-held-the-7th-tofuconf.html
  *  External link https://t.co/6P5jBnrFqI failed: 400 No error
  *  External link https://twitter.com/hashtag/tofuconf?src=hash&ref_src=twsrc%5Etfw failed: 400 No error
  *  External link https://twitter.com/tofuConf/status/1266608717132267520?ref_src=twsrc%5Etfw failed: 400 No error
- ./_site/2020-09-24/we-held-the-8th-tofuconf.html
  *  External link https://t.co/OFeEF3wZ2U failed: 400 No error
  *  External link https://twitter.com/intent/tweet?via=tofuconf&text=tofuConf%238%E3%82%92%E9%96%8B%E5%82%AC%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F%20%2F2020-09-24%2Fwe-held-the-8th-tofuconf.html failed: 400 No error
  *  External link https://twitter.com/tofuConf/status/1299937119553552384?ref_src=twsrc%5Etfw failed: 400 No error
  *  External link https://www.linkedin.com/shareArticle?mini=true&url=%2F2020-09-24%2Fwe-held-the-8th-tofuconf.html failed: 999 No error
- ./_site/2020-10-15/9th-tofuconf-general.html
  *  External link https://t.co/rmP159yMCJ failed: 400 No error
  *  External link https://twitter.com/tofuConf/status/1326531560108032001?ref_src=twsrc%5Etfw failed: 400 No error
- ./_site/404.html
  *  External link https://twitter.com/tofuconf failed: 400 No error
- ./_site/page3/index.html
  *  External link https://twitter.com/tofuConf?ref_src=twsrc%5Etfw failed: 400 No error

HTML-Proofer found 31 failures!
Error: Process completed with exit code 1.
```