### PR TITLE
GitHub Actions関連のメンテナンス

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: "0"
           submodules: "true"
 
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "2.7"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Verify URL in HTML
         continue-on-error: true
         run: |
-          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/" ./_site
+          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/," ./_site
 
       - name: Prepare SSH 1
         uses: webfactory/ssh-agent@v0.8.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Verify URL in HTML
         continue-on-error: true
         run: |
-          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/,/twitter.com/,/t.co/,/www.facebook.com/sharer/sharer.php.*/" ./_site
+          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/,/twitter.com/,/t.co/,/www.facebook.com/sharer/sharer.php.*/,/www.kyash.co/" ./_site
 
       - name: Prepare SSH 1
         uses: webfactory/ssh-agent@v0.8.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Verify URL in HTML
         continue-on-error: true
         run: |
-          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/," ./_site
+          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/,/twitter.com/,/t.co/" ./_site
 
       - name: Prepare SSH 1
         uses: webfactory/ssh-agent@v0.8.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Verify URL in HTML
         continue-on-error: true
         run: |
-          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/,/twitter.com/,/t.co/" ./_site
+          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/,/twitter.com/,/t.co/,/www.facebook.com/sharer/sharer.php.*/" ./_site
 
       - name: Prepare SSH 1
         uses: webfactory/ssh-agent@v0.8.0

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-ruby@v1.1.1
         with:
-          ruby-version: "2.7"
+          ruby-version: "2.7.8
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Verify URL in HTML
         run: |
-          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/" ./_site
+          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/,/twitter.com/,/t.co/" ./_site
 
       - name: Deploy to Netlify
         if: ${{ always() }}

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: "0"
           submodules: "true"
 
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "2.7"
 

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -14,16 +14,16 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
           submodules: "true"
 
-      - uses: actions/setup-ruby@v1.1.1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7.8"
+          ruby-version: "2.7"
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Verify URL in HTML
         run: |
-          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/,/twitter.com/,/t.co/,/www.facebook.com/sharer/sharer.php.*/" ./_site
+          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/,/twitter.com/,/t.co/,/www.facebook.com/sharer/sharer.php.*/,/www.kyash.co/" ./_site
 
       - name: Deploy to Netlify
         if: ${{ always() }}

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Verify URL in HTML
         run: |
-          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/,/twitter.com/,/t.co,/www.facebook.com/sharer/sharer.php.*//" ./_site
+          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/,/twitter.com/,/t.co/,/www.facebook.com/sharer/sharer.php.*/" ./_site
 
       - name: Deploy to Netlify
         if: ${{ always() }}

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: "0"
           submodules: "true"
 
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/setup-ruby@v1.1.1
         with:
           ruby-version: "2.7"
 

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Verify URL in HTML
         run: |
-          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/,/twitter.com/,/t.co/" ./_site
+          bundle exec htmlproofer --enforce_https false --ignore-status-codes "400,999" --ignore-urls "/#.*/,/tofuconf.club/.*/,/twitter.com/,/t.co,/www.facebook.com/sharer/sharer.php.*//" ./_site
 
       - name: Deploy to Netlify
         if: ${{ always() }}

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-ruby@v1.1.1
         with:
-          ruby-version: "2.7.8
+          ruby-version: "2.7.8"
 
       - uses: actions/cache@v3
         with:

--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ title_separator: "-"
 name: "tofuConf"
 description: "tofuConf Official Website"
 url: "https://tofuconf.club" # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
-# baseurl: # the subpath of your site, e.g. "/blog"
+baseurl: # the subpath of your site, e.g. "/blog"
 repository: "tofuconf/tofuconf.club" # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"
 teaser: "/images/favicons/icon-196x196.png" # path of fallback teaser image, e.g. "/assets/images/500x300.png"
 # breadcrumbs            : false # true, false (default)

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@
 # `jekyll serve`. If you change this file, please restart the server process.
 
 # Theme
-remote_theme: mmistakes/minimal-mistakes@4.9.0
+remote_theme: mmistakes/minimal-mistakes@4.24.0
 minimal_mistakes_skin: "contrast" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
 
 # Site Settings

--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ title_separator: "-"
 name: "tofuConf"
 description: "tofuConf Official Website"
 url: "https://tofuconf.club" # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
-baseurl: # the subpath of your site, e.g. "/blog"
+# baseurl: # the subpath of your site, e.g. "/blog"
 repository: "tofuconf/tofuconf.club" # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"
 teaser: "/images/favicons/icon-196x196.png" # path of fallback teaser image, e.g. "/assets/images/500x300.png"
 # breadcrumbs            : false # true, false (default)


### PR DESCRIPTION
https://github.com/tofuconf/tofuconf.club/pull/465 でGitHub ActionsのRunnerがジョブを拾わなくなってしまったことの対策

- 保守の終了したactions/setup-ruby アクションから ruby/setup-rubyアクションに変更 ([Link](https://github.com/actions/setup-ruby#:~:text=This%20action%20is%20deprecated%20and%20should%20no%20longer%20be%20used.%20The%20team%20at%20GitHub%20has%20ceased%20making%20and%20accepting%20code%20contributions%20or%20maintaining%20issues%20tracker.%20Please%2C%20migrate%20your%20workflows%20to%20the%20ruby/setup%2Druby%2C%20which%20is%20being%20actively%20maintained%20by%20the%20official%20Ruby%20organization.))
- DeprecatedになったUbuntu 18.04から Ubuntu 22.04に変更 ([Link](https://github.com/actions/runner-images/issues/6002))
- Twitter関連ドメインを`ignore-urls`に追加 ([Link](https://twitter.com/elonmusk/status/1674865731136020505?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1674865731136020505%7Ctwgr%5Ed1c6bf4f52e07b94603e68b64a9d946a9fed6fa7%7Ctwcon%5Es1_&ref_url=https%3A%2F%2Fwww.itmedia.co.jp%2Fnews%2Farticles%2F2307%2F01%2Fnews055.html))
- Facebookの共有リンクチェックを無効化
- kyashのリンクチェックを無効化