### PR TITLE
トップ画面からTwitterを除去

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,4 @@ author_profile: true
 <div class="archive">
     <a href="/about/"><img src="/images/logo.png" alt="tofuconf logo" width="100%"></a>
     <p>tofuConf公式サイトです。tofuConfについては<a href="/about/">こちら</a>。</p>
-    <a class="twitter-timeline" data-width="100%" data-height="500"
-        href="https://twitter.com/tofuConf?ref_src=twsrc%5Etfw">Tweets by tofuConf</a>
-    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>


### PR DESCRIPTION
Twitterの仕様変更により、ブラウザでTwitterにログインしていない環境ではTwitterのタイムラインを表示できなくなったため、トップ画面からTwitterのウィジェットを除去します。